### PR TITLE
[CUBVEC-90] fix: improve QPS by 'preparing' statement just for once

### DIFF
--- a/ann_benchmarks/algorithms/cubrid/module.py
+++ b/ann_benchmarks/algorithms/cubrid/module.py
@@ -52,17 +52,11 @@ def get_cub_conn_param(cub_param_name: str, default_value: Optional[str] = None)
         return default_value
     return env_var_value
 class CUBVEC(BaseANN):
-
-    def done(self) -> None:
-        print("### done")
-
     def __init__(self, metric, method_param):
         self._metric = metric
         self._m = method_param['M']
         self._ef_construction = method_param['efConstruction']
         self._cur = None
-        self.is_prepared = False
-
         self._signature_base = metric + "_" + str(self._m) + "_" + str(self._ef_construction)
         self._signature = self._signature_base
 
@@ -102,7 +96,6 @@ class CUBVEC(BaseANN):
         self._ef_search = ef_search
         self._cur.execute("SET SYSTEM PARAMETERS 'hnsw_ef_search=%d'" % ef_search)
 
-        print("### preparing query...")
         query_str = self._query.format(self._signature)
         self._cur._cs.prepare(query_str)
 
@@ -118,10 +111,8 @@ class CUBVEC(BaseANN):
         r = cur._cs.execute()
         cur.rowcount = cur._cs.rowcount
         cur.description = cur._cs.description
-        # return r
 
-        res = [id for id, in cur.fetchall()]
-        return res
+        return [id for id, in cur.fetchall()]
 
     def _open_connection_primitive(self, host, port, database, user, password):
         url = f"CUBRID:{host}:{port}:{database}:::"


### PR DESCRIPTION
http://jira.cubrid.org/browse/CUBVEC-90

## Purpose
### ASIS
execute를 할 때마다 매번 prepare를 하기 때문에 최대 QPS가 700 이하로 나온다.
현재 cubrid python 드라이버의 한계로 추정된다. 

### TOBE
1만번마다 1번만 prepare를 하도록 python driver를 우회한다.

## Implementation

set_query_arguments() 는 하나의 run_group에서 argument를 설정할 때 1번만 실행된다.
그곳에서 self._cur._cs 를 이용해 prepare를 수행한다.

query() 는 매번 수행된다.
이미 prepare된 self._cur 를 재사용하여, 바뀐 vector argument를 매번 bind 한다.

참고:
https://github.com/CUBRID/cubrid-python/blob/a29c3cb29df143b4a433749ae8cb4a39053fa155/CUBRIDdb/cursors.py#L91

위 코드를 그대로 복사해 가져온 것이며, 이렇게 사용해도 되는지에 대해 검증하지 않았습니다.
Erikbern 벤치마크에서 이렇게 설정하면 Recall 대비 QPS 성능이 대폭 상승하는 것을 관찰했습니다.